### PR TITLE
[codex] Restrict browser DB query proxy

### DIFF
--- a/app/api/db/query/route.ts
+++ b/app/api/db/query/route.ts
@@ -1,21 +1,77 @@
 import { NextResponse } from "next/server";
-import { withSurreal } from "@/lib/server/surreal";
+import { DbOperationError, executeDbOperation } from "@/lib/server/db/operations";
 
 export const runtime = "nodejs";
 
-type Body = { sql?: string; vars?: Record<string, unknown> };
+type Body = {
+  operation?: string;
+  vars?: Record<string, unknown>;
+  sql?: unknown;
+};
 
 export async function POST(req: Request) {
-  const body = (await req.json()) as Body;
-  const sql = (body?.sql || "").toString();
-  const vars = (body?.vars || {}) as Record<string, unknown>;
-  if (!sql) return NextResponse.json({ error: "Missing sql" }, { status: 400 });
+  if (!isAuthorizedRequest(req)) {
+    return NextResponse.json({ error: "DB query API requires same-origin access" }, { status: 401 });
+  }
 
   try {
-    const result = await withSurreal(async (client) => client.query(sql, vars));
+    const body = await readBody(req);
+    if (body?.sql !== undefined) {
+      return NextResponse.json({ error: "Raw SQL is not accepted by this API" }, { status: 403 });
+    }
+
+    const operation = typeof body?.operation === "string" ? body.operation : "";
+    if (!operation) {
+      return NextResponse.json({ error: "Missing operation" }, { status: 400 });
+    }
+
+    const result = await executeDbOperation(operation, body?.vars ?? {});
     return NextResponse.json(result);
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 });
+  } catch (e: unknown) {
+    if (e instanceof DbOperationError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    return NextResponse.json({ error: e instanceof Error ? e.message : String(e) }, { status: 500 });
   }
 }
 
+async function readBody(req: Request): Promise<Body> {
+  try {
+    return (await req.json()) as Body;
+  } catch {
+    throw new DbOperationError("Invalid JSON body", 400);
+  }
+}
+
+function isAuthorizedRequest(req: Request): boolean {
+  const token = process.env.DB_QUERY_API_TOKEN;
+  const auth = req.headers.get("authorization") || "";
+  if (token && auth === `Bearer ${token}`) return true;
+
+  const requestUrl = new URL(req.url);
+  const host = req.headers.get("host");
+  const forwardedProto = req.headers.get("x-forwarded-proto");
+  const hostOrigin = host ? `${forwardedProto || requestUrl.protocol.replace(":", "")}://${host}` : undefined;
+  const allowedOrigins = new Set([
+    requestUrl.origin,
+    hostOrigin,
+    process.env.APP_ORIGIN,
+    process.env.NEXT_PUBLIC_APP_ORIGIN,
+    process.env.BASE_URL,
+  ].filter((value): value is string => Boolean(value)));
+
+  const origin = req.headers.get("origin");
+  if (origin) return allowedOrigins.has(origin);
+
+  const fetchSite = req.headers.get("sec-fetch-site");
+  if (fetchSite === "same-origin") return true;
+
+  const referer = req.headers.get("referer");
+  if (!referer) return false;
+
+  try {
+    return allowedOrigins.has(new URL(referer).origin);
+  } catch {
+    return false;
+  }
+}

--- a/components/surreal/SurrealProvider.tsx
+++ b/components/surreal/SurrealProvider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { resolveDbOperation } from "@/lib/db/operation-map";
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 interface SurrealProviderProps {
   children: React.ReactNode
@@ -42,10 +43,14 @@ export function SurrealProvider({ children, autoConnect = true }: SurrealProvide
 
   const apiClient: ApiSurrealLike = useMemo(() => ({
     query: async (sql: string, vars?: Record<string, unknown>) => {
+      const operation = resolveDbOperation(sql);
+      if (!operation) {
+        throw new Error("DB operation is not allowed");
+      }
       const res = await fetch("/api/db/query", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql, vars }),
+        body: JSON.stringify({ operation, vars }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({} as any));

--- a/lib/db/operation-map.ts
+++ b/lib/db/operation-map.ts
@@ -1,0 +1,75 @@
+export const DB_OPERATION_SQL = {
+  hardwareMetricsList: "SELECT * FROM hardware_metric ORDER BY ts ASC",
+
+  datasetsListFiles: "SELECT dataset, uploadedAt, mime, name, key, dead FROM file",
+  datasetsListNames: "SELECT dataset FROM file GROUP BY dataset;",
+  datasetCheckExists: "SELECT id FROM file WHERE dataset = $dataset LIMIT 1",
+  datasetCreateFile: "CREATE file SET name = $name, key = $key, bucket = $bucket, size = $size, mime = $mime, dataset = $dataset, encode = $encode, uploadedAt = time::now(), thumbKey = $thumbKey",
+  datasetFilesByName: "SELECT * FROM file WHERE dataset == $dataset ORDER BY name ASC",
+  datasetSoftDelete: "UPDATE file SET dead = true WHERE dataset = $dataset",
+  datasetNavFiles: "SELECT id, name, key, bucket, dead FROM file WHERE dataset == $dataset ORDER BY name ASC",
+  fileById: "SELECT * FROM file WHERE id == <record> $id LIMIT 1;",
+  fileSoftDeleteById: "UPDATE file SET dead = true WHERE id = <record> $id",
+  fileSoftDeleteByDatasetKey: "UPDATE file SET dead = true WHERE dataset = $dataset AND key = $key",
+
+  mergeGroupDeleteAll: "DELETE merge_group WHERE dataset == $dataset AND mode == 'all'",
+  mergeGroupCreateAll: "CREATE merge_group CONTENT { dataset: $dataset, mode: 'all', members: $members, createdAt: time::now() }",
+  mergeGroupGetAll: "SELECT * FROM merge_group WHERE dataset == $dataset AND mode == 'all' LIMIT 1",
+  hlsJobsByDataset: "SELECT file, status, created_at FROM hls_job WHERE file.dataset == $dataset ORDER BY created_at DESC",
+  hlsPlaylistByFile: "SELECT * FROM hls_playlist WHERE file = <record> $id LIMIT 1;",
+
+  labelNamesByDataset: "SELECT name FROM label WHERE dataset == $dataset",
+  labelsByDataset: "SELECT * FROM label WHERE dataset == $dataset ORDER BY name ASC",
+  labelCreate: "CREATE label CONTENT { dataset: $dataset, name: $name }",
+  labelDelete: "DELETE label WHERE dataset == $dataset AND name == $name",
+
+  annotationPresenceByDataset: "SELECT file, array::distinct(category) AS cats FROM annotation WHERE dataset == $dataset GROUP BY file",
+  annotationsImageByFile: "SELECT * FROM annotation WHERE file == <record> $fid AND (category = 'image_bbox' OR category = NONE)",
+  annotationsVideoByFile: "SELECT * FROM annotation WHERE file == <record> $fid AND category = 'sam2_key_bbox'",
+  annotationTextByFile: "SELECT * FROM annotation WHERE file == <record> $fid AND category = 'text_label' LIMIT 1",
+  annotationCreateBox: "CREATE annotation CONTENT { dataset: $dataset, file: <record> $file, label: $label, category: $category, x1: $x1, y1: $y1, x2: $x2, y2: $y2 }",
+  annotationCreateText: "CREATE annotation CONTENT { dataset: $dataset, file: <record> $file, category: 'text_label', text: $text }",
+  annotationUpdateText: "UPDATE annotation SET text = $text WHERE id = <record> $id",
+  annotationDeleteById: "DELETE annotation WHERE id = <record> $id",
+  annotationDeleteByDatasetLabel: "DELETE annotation WHERE dataset == $dataset AND label == $name",
+  inferenceJobsList: "SELECT * FROM inference_job ORDER BY updatedAt DESC",
+  inferenceJobByName: "SELECT * FROM inference_job WHERE name == $name ORDER BY updatedAt DESC LIMIT 1",
+  inferenceJobProgressByName: "SELECT progress FROM inference_job WHERE name == $name LIMIT 1",
+  inferenceJobCheckByName: "SELECT id, dead FROM inference_job WHERE name == $name LIMIT 1",
+  inferenceJobCreate: "CREATE inference_job CONTENT { name: $name, dead: false, status: 'ProcessWaiting', taskType: $taskType, model: $model, modelSource: $modelSource, datasets: $datasets, createdAt: time::now(), updatedAt: time::now() }",
+  inferenceJobUpdate: "UPDATE inference_job SET dead = false, status = 'ProcessWaiting', taskType = $taskType, model = $model, modelSource = $modelSource, datasets = $datasets, updatedAt = time::now() WHERE name == $name",
+  inferenceJobSoftDelete: "UPDATE inference_job SET dead = true, updatedAt = time::now() WHERE name == $name",
+  inferenceJobStop: "UPDATE inference_job SET status = 'StopInterrept', updatedAt = time::now() WHERE name == $name",
+  inferenceJobCopy: "CREATE inference_job SET name = $name, status = 'ProcessWaiting', taskType = $taskType, model = $model, modelSource = $modelSource, datasets = $datasets, createdAt = time::now(), updatedAt = time::now()",
+  inferenceResultsByJob: "SELECT * FROM inference_result WHERE job == <record> $job ORDER BY createdAt DESC",
+
+  completedTrainingJobs: "SELECT name FROM training_job WHERE status IN ['Complete', 'Completed']",
+  trainingJobsList: "SELECT * FROM training_job ORDER BY updatedAt DESC",
+  trainingJobByName: "SELECT * FROM training_job WHERE name == $name ORDER BY updatedAt DESC LIMIT 1",
+  trainingJobCheckByName: "SELECT id FROM training_job WHERE name == $name LIMIT 1",
+  trainingJobCreate: "CREATE training_job CONTENT { name: $name, status: 'ProcessWaiting', taskType: $taskType, model: $model, datasets: $datasets, labels: $labels, epochs: $epochs, batchSize: $batchSize, splitTrain: $splitTrain, splitTest: $splitTest, createdAt: time::now(), updatedAt: time::now() }",
+  trainingJobUpdate: "UPDATE training_job SET status = 'ProcessWaiting', taskType = $taskType, model = $model, datasets = $datasets, labels = $labels, epochs = $epochs, batchSize = $batchSize, splitTrain = $splitTrain, splitTest = $splitTest, updatedAt = time::now() WHERE name == $name",
+  trainingJobDelete: "DELETE training_job WHERE name == $name",
+  trainingJobStop: "UPDATE training_job SET status = 'StopInterrept', updatedAt = time::now() WHERE name == $name",
+} as const;
+
+export type DbOperation = keyof typeof DB_OPERATION_SQL;
+
+const SQL_TO_OPERATION = new Map<string, DbOperation>(
+  Object.entries(DB_OPERATION_SQL).map(([operation, sql]) => [
+    normalizeDbSql(sql),
+    operation as DbOperation,
+  ]),
+);
+
+export function normalizeDbSql(sql: string): string {
+  return sql.trim().replace(/\s+/g, " ");
+}
+
+export function resolveDbOperation(sql: string): DbOperation | undefined {
+  return SQL_TO_OPERATION.get(normalizeDbSql(sql));
+}
+
+export function isDbOperation(value: string): value is DbOperation {
+  return Object.prototype.hasOwnProperty.call(DB_OPERATION_SQL, value);
+}

--- a/lib/server/db/operations.ts
+++ b/lib/server/db/operations.ts
@@ -1,0 +1,239 @@
+import { DB_OPERATION_SQL, type DbOperation, isDbOperation } from "@/lib/db/operation-map";
+import { withSurreal } from "@/lib/server/surreal";
+
+type Vars = Record<string, unknown>;
+type VarKind = "string" | "number" | "stringArray" | "optionalString" | "optionalNumber";
+type VarRule = { kind: VarKind; values?: readonly string[] };
+type VarSchema = Record<string, VarRule>;
+
+const stringRule: VarRule = { kind: "string" };
+const numberRule: VarRule = { kind: "number" };
+const stringArrayRule: VarRule = { kind: "stringArray" };
+const optionalStringRule: VarRule = { kind: "optionalString" };
+const optionalNumberRule: VarRule = { kind: "optionalNumber" };
+
+const MUTATION_OPERATIONS = new Set<DbOperation>([
+  "datasetCreateFile",
+  "datasetSoftDelete",
+  "fileSoftDeleteById",
+  "fileSoftDeleteByDatasetKey",
+  "mergeGroupDeleteAll",
+  "mergeGroupCreateAll",
+  "labelCreate",
+  "labelDelete",
+  "annotationCreateBox",
+  "annotationCreateText",
+  "annotationUpdateText",
+  "annotationDeleteById",
+  "annotationDeleteByDatasetLabel",
+  "inferenceJobCreate",
+  "inferenceJobUpdate",
+  "inferenceJobSoftDelete",
+  "inferenceJobStop",
+  "inferenceJobCopy",
+  "trainingJobCreate",
+  "trainingJobUpdate",
+  "trainingJobDelete",
+  "trainingJobStop",
+]);
+
+const OPERATION_SCHEMAS: Partial<Record<DbOperation, VarSchema>> = {
+  datasetCheckExists: { dataset: stringRule },
+  datasetCreateFile: {
+    name: stringRule,
+    key: stringRule,
+    bucket: stringRule,
+    size: numberRule,
+    mime: stringRule,
+    dataset: stringRule,
+    encode: optionalStringRule,
+    thumbKey: optionalStringRule,
+    now: optionalStringRule,
+  },
+  datasetFilesByName: { dataset: stringRule },
+  datasetSoftDelete: { dataset: stringRule },
+  datasetNavFiles: { dataset: stringRule },
+  fileById: { id: stringRule },
+  fileSoftDeleteById: { id: stringRule },
+  fileSoftDeleteByDatasetKey: { dataset: stringRule, key: stringRule },
+
+  mergeGroupDeleteAll: { dataset: stringRule },
+  mergeGroupCreateAll: { dataset: stringRule, members: stringArrayRule },
+  mergeGroupGetAll: { dataset: stringRule },
+  hlsJobsByDataset: { dataset: stringRule },
+  hlsPlaylistByFile: { id: stringRule },
+
+  labelNamesByDataset: { dataset: stringRule },
+  labelsByDataset: { dataset: stringRule },
+  labelCreate: { dataset: stringRule, name: stringRule },
+  labelDelete: { dataset: stringRule, name: stringRule },
+
+  annotationPresenceByDataset: { dataset: stringRule },
+  annotationsImageByFile: { fid: stringRule },
+  annotationsVideoByFile: { fid: stringRule },
+  annotationTextByFile: { fid: stringRule },
+  annotationCreateBox: {
+    dataset: stringRule,
+    file: stringRule,
+    label: optionalStringRule,
+    category: { kind: "string", values: ["image_bbox", "sam2_key_bbox"] },
+    x1: numberRule,
+    y1: numberRule,
+    x2: numberRule,
+    y2: numberRule,
+  },
+  annotationCreateText: { dataset: stringRule, file: stringRule, text: stringRule },
+  annotationUpdateText: { id: stringRule, text: stringRule },
+  annotationDeleteById: { id: stringRule },
+  annotationDeleteByDatasetLabel: { dataset: stringRule, name: stringRule },
+
+  inferenceJobByName: { name: stringRule },
+  inferenceJobProgressByName: { name: stringRule },
+  inferenceJobCheckByName: { name: stringRule },
+  inferenceJobCreate: {
+    name: stringRule,
+    status: optionalStringRule,
+    taskType: stringRule,
+    model: stringRule,
+    modelSource: { kind: "string", values: ["internet", "trained"] },
+    datasets: stringArrayRule,
+  },
+  inferenceJobUpdate: {
+    name: stringRule,
+    status: optionalStringRule,
+    taskType: stringRule,
+    model: stringRule,
+    modelSource: { kind: "string", values: ["internet", "trained"] },
+    datasets: stringArrayRule,
+  },
+  inferenceJobSoftDelete: { name: stringRule },
+  inferenceJobStop: { name: stringRule },
+  inferenceJobCopy: {
+    name: stringRule,
+    taskType: stringRule,
+    model: stringRule,
+    modelSource: optionalStringRule,
+    datasets: stringArrayRule,
+  },
+  inferenceResultsByJob: { job: stringRule },
+
+  trainingJobByName: { name: stringRule },
+  trainingJobCheckByName: { name: stringRule },
+  trainingJobCreate: {
+    name: stringRule,
+    status: optionalStringRule,
+    taskType: stringRule,
+    model: stringRule,
+    datasets: stringArrayRule,
+    labels: stringArrayRule,
+    epochs: optionalNumberRule,
+    batchSize: optionalNumberRule,
+    splitTrain: numberRule,
+    splitTest: numberRule,
+  },
+  trainingJobUpdate: {
+    name: stringRule,
+    status: optionalStringRule,
+    taskType: stringRule,
+    model: stringRule,
+    datasets: stringArrayRule,
+    labels: stringArrayRule,
+    epochs: optionalNumberRule,
+    batchSize: optionalNumberRule,
+    splitTrain: numberRule,
+    splitTest: numberRule,
+  },
+  trainingJobDelete: { name: stringRule },
+  trainingJobStop: { name: stringRule },
+};
+
+export class DbOperationError extends Error {
+  constructor(message: string, public readonly status = 400) {
+    super(message);
+  }
+}
+
+export async function executeDbOperation(operation: string, vars: Vars) {
+  if (!isDbOperation(operation)) {
+    throw new DbOperationError("DB operation is not allowed", 403);
+  }
+  if (!isVarsObject(vars)) {
+    throw new DbOperationError("Invalid vars", 400);
+  }
+
+  const validatedVars = validateVars(operation, vars);
+  auditDbOperation(operation, validatedVars);
+
+  return withSurreal(async (client) => client.query(DB_OPERATION_SQL[operation], validatedVars));
+}
+
+function isVarsObject(value: unknown): value is Vars {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isMutationOperation(operation: string): boolean {
+  return isDbOperation(operation) && MUTATION_OPERATIONS.has(operation);
+}
+
+function validateVars(operation: DbOperation, vars: Vars): Vars {
+  const schema = OPERATION_SCHEMAS[operation] ?? {};
+  const allowed = new Set(Object.keys(schema));
+  const validated: Vars = {};
+
+  for (const key of Object.keys(vars)) {
+    if (!allowed.has(key) && vars[key] !== undefined && vars[key] !== null) {
+      throw new DbOperationError(`Unexpected variable: ${key}`, 400);
+    }
+  }
+
+  for (const [key, rule] of Object.entries(schema)) {
+    const value = vars[key];
+    if (isOptional(rule) && (value === undefined || value === null)) {
+      continue;
+    }
+    validated[key] = validateValue(key, value, rule);
+  }
+
+  return validated;
+}
+
+function isOptional(rule: VarRule): boolean {
+  return rule.kind === "optionalString" || rule.kind === "optionalNumber";
+}
+
+function validateValue(key: string, value: unknown, rule: VarRule): unknown {
+  const kind = rule.kind.replace("optional", "").toLowerCase();
+  if (kind === "string") {
+    if (typeof value !== "string" || value.length === 0) {
+      throw new DbOperationError(`Invalid variable: ${key}`, 400);
+    }
+    if (rule.values && !rule.values.includes(value)) {
+      throw new DbOperationError(`Invalid variable value: ${key}`, 400);
+    }
+    return value;
+  }
+
+  if (kind === "number") {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new DbOperationError(`Invalid variable: ${key}`, 400);
+    }
+    return value;
+  }
+
+  if (kind === "stringarray") {
+    if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+      throw new DbOperationError(`Invalid variable: ${key}`, 400);
+    }
+    return value;
+  }
+
+  throw new DbOperationError(`Unsupported variable rule: ${key}`, 500);
+}
+
+function auditDbOperation(operation: DbOperation, vars: Vars): void {
+  console.info("[db-operation]", JSON.stringify({
+    operation,
+    mutation: isMutationOperation(operation),
+    varKeys: Object.keys(vars).sort(),
+  }));
+}


### PR DESCRIPTION
## Summary
- Restricts the browser-facing database query proxy to an allowlisted set of safe operations.
- Blocks arbitrary SQL execution from the UI API surface.

## Why
The previous proxy shape was too permissive for a browser-accessible endpoint. This is the short-term safety hardening for the P0 arbitrary SQL proxy finding.

## Validation
- E2E security coverage was added in the companion mlops-cloud PR.
- Existing local checks were run during implementation.
