### PR TITLE
[codex] Fix root provider hydration mismatch

### DIFF
--- a/app/provider.tsx
+++ b/app/provider.tsx
@@ -10,6 +10,16 @@ import { LanguageProvider } from "@/components/i18n/LanguageProvider";
 const queryClient = new QueryClient();
 
 export default function RootLayout(props: { children: React.ReactNode; initialLang?: "en" | "ja" }) {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
   return (
     <ChakraProvider value={defaultSystem}>
       <ColorModeProvider forcedTheme="light" attribute="class" disableTransitionOnChange>

--- a/components/ui/color-mode.tsx
+++ b/components/ui/color-mode.tsx
@@ -2,18 +2,8 @@
 
 import type { IconButtonProps, SpanProps } from "@chakra-ui/react";
 import { ClientOnly, IconButton, Skeleton, Span } from "@chakra-ui/react";
-import { ThemeProvider, useTheme } from "next-themes";
-import type { ThemeProviderProps } from "next-themes";
 import * as React from "react";
 import { LuMoon, LuSun } from "react-icons/lu";
-
-export interface ColorModeProviderProps extends ThemeProviderProps {}
-
-export function ColorModeProvider(props: ColorModeProviderProps) {
-  return (
-    <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
-  );
-}
 
 export type ColorMode = "light" | "dark"
 
@@ -23,17 +13,52 @@ export interface UseColorModeReturn {
   toggleColorMode: () => void
 }
 
-export function useColorMode(): UseColorModeReturn {
-  const { resolvedTheme, setTheme, forcedTheme } = useTheme();
-  const colorMode = forcedTheme || resolvedTheme;
-  const toggleColorMode = () => {
-    setTheme(resolvedTheme === "dark" ? "light" : "dark");
-  };
-  return {
-    colorMode: colorMode as ColorMode,
-    setColorMode: setTheme,
+export interface ColorModeProviderProps {
+  children?: React.ReactNode
+  forcedTheme?: ColorMode
+  defaultTheme?: ColorMode
+  attribute?: string
+  disableTransitionOnChange?: boolean
+}
+
+const ColorModeContext = React.createContext<UseColorModeReturn | undefined>(undefined);
+
+export function ColorModeProvider({
+  children,
+  forcedTheme,
+  defaultTheme = "light",
+}: ColorModeProviderProps) {
+  const [theme, setTheme] = React.useState<ColorMode>(defaultTheme);
+  const colorMode = forcedTheme ?? theme;
+  const setColorMode = React.useCallback((next: ColorMode) => {
+    if (!forcedTheme) {
+      setTheme(next);
+    }
+  }, [forcedTheme]);
+  const toggleColorMode = React.useCallback(() => {
+    if (!forcedTheme) {
+      setTheme((current) => current === "dark" ? "light" : "dark");
+    }
+  }, [forcedTheme]);
+  const value = React.useMemo<UseColorModeReturn>(() => ({
+    colorMode,
+    setColorMode,
     toggleColorMode,
-  };
+  }), [colorMode, setColorMode, toggleColorMode]);
+
+  return (
+    <ColorModeContext.Provider value={value}>
+      {children}
+    </ColorModeContext.Provider>
+  );
+}
+
+export function useColorMode(): UseColorModeReturn {
+  const context = React.useContext(ColorModeContext);
+  if (!context) {
+    throw new Error("useColorMode must be used within ColorModeProvider");
+  }
+  return context;
 }
 
 export function useColorModeValue<T>(light: T, dark: T) {

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   turbopack: {},
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "next-app",
-  "version": "2.0.14",
+  "name": "mlops-cloud-ui",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-app",
-      "version": "2.0.14",
+      "name": "mlops-cloud-ui",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.863.0",
@@ -20,7 +20,6 @@
         "@types/react-dom": "19.1.6",
         "hls.js": "^1.5.16",
         "next": "^16.0.0",
-        "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -7360,16 +7359,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/@swc/helpers": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,12 @@
     "@types/node": "^24.0.4",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
+    "hls.js": "^1.5.16",
     "next": "^16.0.0",
-    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "surrealdb": "^1.3.2",
-    "hls.js": "^1.5.16",
     "typescript": "^5.8.3"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Remove `next-themes` from the root provider path to avoid injecting a client-only theme script during hydration.
- Replace color mode wiring with a lightweight local provider while preserving the existing light-mode behavior.
- Defer Chakra/Emotion-backed UI rendering until after client mount so the server/client DOM trees no longer disagree in dev.
- Fix `next.config.js` semicolon lint errors encountered during validation.

## Root Cause
The root provider stack rendered Chakra/Emotion global styles during SSR while `next-themes` injected client-side DOM during hydration. In Next 16/React 19 this caused recoverable hydration mismatches where the client expected provider/script/style nodes in a different order than the server HTML.

## Validation
- `npm run type-check`
- `npm run build`
- `npm run lint` -> exit 0 with existing warnings only
- Dev server + Playwright opened `/dataset`; hydration mismatch pageerror no longer appears
- `docker compose -f e2e/compose.phase1.yml up --build --abort-on-container-exit --exit-code-from e2e e2e` -> 7 passed, 3 skipped
